### PR TITLE
Fixes SerializedName For TGEvent#location/priority (fixes #2)

### DIFF
--- a/tapglue-android-sdk/src/main/java/com/tapglue/model/TGEvent.java
+++ b/tapglue-android-sdk/src/main/java/com/tapglue/model/TGEvent.java
@@ -33,7 +33,7 @@ public class TGEvent extends TGBaseObjectWithId<TGEvent> {
     @SerializedName("latitude")
     private Float mLatitude;
     @Expose
-    @SerializedName("mLocation")
+    @SerializedName("location")
     private String mLocation;
     @Expose
     @SerializedName("longitude")
@@ -45,7 +45,7 @@ public class TGEvent extends TGBaseObjectWithId<TGEvent> {
     @SerializedName("object")
     private TGEventObject mObject;
     @Expose
-    @SerializedName("mPriority")
+    @SerializedName("priority")
     private String mPriority;
     @Expose
     @SerializedName("target")


### PR DESCRIPTION
Both SerializedName annotations had the m prefix. This broke the serialization / deserialization.

Addresses #2
