### PR TITLE
Fix acceptance tests depending on old data

### DIFF
--- a/tapglue-android-sdk/src/androidTest/java/com/tapglue/android/ConnectionIntegrationTest.java
+++ b/tapglue-android-sdk/src/androidTest/java/com/tapglue/android/ConnectionIntegrationTest.java
@@ -26,8 +26,8 @@ import static org.junit.Assert.assertThat;
 public class ConnectionIntegrationTest extends ApplicationTestCase<Application>{
 
     private static final String PASSWORD = "superSecretPassword";
-    private static final String USER_1 = "user10";
-    private static final String USER_2 = "user20";
+    private static final String USER_1 = "ConnectionIntegrationTestUser10";
+    private static final String USER_2 = "ConnectionIntegrationTestUser20";
 
     Configuration configuration;
     Tapglue tapglue;

--- a/tapglue-android-sdk/src/androidTest/java/com/tapglue/android/LoginIntegrationTest.java
+++ b/tapglue-android-sdk/src/androidTest/java/com/tapglue/android/LoginIntegrationTest.java
@@ -78,7 +78,7 @@ public class LoginIntegrationTest extends ApplicationTestCase<Application> {
 
     public void testLoginWithWrongCredentials() throws IOException {
         try {
-            tapglue.loginWithUsername("johnnnn", PasswordHasher.hashPassword("qwert"));
+            tapglue.loginWithUsername("johnnnn12315233212", PasswordHasher.hashPassword("qwert"));
             fail("did not throw TapglueError on wrong credentials");
         } catch(TapglueError e) {
 

--- a/tapglue-android-sdk/src/androidTest/java/com/tapglue/android/RxLoginIntegrationTest.java
+++ b/tapglue-android-sdk/src/androidTest/java/com/tapglue/android/RxLoginIntegrationTest.java
@@ -50,7 +50,7 @@ public class RxLoginIntegrationTest extends ApplicationTestCase<Application> {
         IntegrationObserver<User> ts = new IntegrationObserver<User>() {
             @Override
             public void onNext(User user) {
-                assertThat(user.getEmail(), equalTo("john@text.com"));
+                assertThat(user.getUserName(), equalTo("john"));
             }
         };
 
@@ -107,7 +107,7 @@ public class RxLoginIntegrationTest extends ApplicationTestCase<Application> {
         IntegrationObserver<User> ts = new IntegrationObserver<User>() {
             @Override
             public void onNext(User user) {
-                assertThat(user.getEmail(), equalTo("john@text.com"));
+                assertThat(user.getUserName(), equalTo("john"));
             }
         };
 


### PR DESCRIPTION
Some acceptance tests relied on data that was not being created by the tests them selves. This has been addressed in this PR.
