### PR TITLE
Add device unregistration for SIMS

### DIFF
--- a/tapglue-android-sdk/src/main/java/com/tapglue/android/sims/SimsService.java
+++ b/tapglue-android-sdk/src/main/java/com/tapglue/android/sims/SimsService.java
@@ -1,6 +1,7 @@
 package com.tapglue.android.sims;
 
 import retrofit2.http.Body;
+import retrofit2.http.DELETE;
 import retrofit2.http.PUT;
 import retrofit2.http.Path;
 import rx.Observable;
@@ -8,4 +9,7 @@ import rx.Observable;
 public interface SimsService {
     @PUT("/0.4/me/devices/{deviceId}")
     Observable<Void> registerDevice(@Path("deviceId") String deviceUUID, @Body DevicePayload payload);
+
+    @DELETE("/0.4/me/devices/{deviceId}")
+    Observable<Void> deleteDevice(@Path("deviceId") String deviceUUID);
 }

--- a/tapglue-android-sdk/src/main/java/com/tapglue/android/sims/TapglueSims.java
+++ b/tapglue-android-sdk/src/main/java/com/tapglue/android/sims/TapglueSims.java
@@ -45,6 +45,38 @@ public class TapglueSims implements NotificationServiceIdListener {
        registerDeviceForSims();
     }
 
+    public void unregisterDevice() {
+        if(!isRegistered.get()) {
+            return;
+        }
+        Observable.combineLatest(notificationIdStore.get(), sessionStore.get(), uuidStore.get(), new Func3<String, User, String, Void>() {
+            @Override
+            public Void call(String notificationId, User session, String uuid) {
+                SimsServiceFactory serviceFactory = new SimsServiceFactory(configuration);
+                serviceFactory.setSessionToken(session.getSessionToken());
+                serviceFactory.setUserUUID(uuid);
+                SimsService service = serviceFactory.createService();
+                service.deleteDevice(uuid);
+                return null;
+            }
+        }).subscribeOn(Schedulers.io()).subscribe(new Observer<Void>() {
+            @Override
+            public void onCompleted() {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+
+            }
+
+            @Override
+            public void onNext(Void aVoid) {
+                isRegistered.set(true);
+            }
+        });
+    }
+
     private void registerDeviceForSims() {
         if(isRegistered.get()) {
             return;

--- a/tapglue-android-sdk/src/main/java/com/tapglue/android/sims/TapglueSims.java
+++ b/tapglue-android-sdk/src/main/java/com/tapglue/android/sims/TapglueSims.java
@@ -72,7 +72,7 @@ public class TapglueSims implements NotificationServiceIdListener {
 
             @Override
             public void onNext(Void aVoid) {
-                isRegistered.set(true);
+                isRegistered.set(false);
             }
         });
     }


### PR DESCRIPTION
When user is logged out the device should be unregistered for notifications. This provides an endpoint for that.